### PR TITLE
ENH: Add 'npm' source validation for visualizers

### DIFF
--- a/q2lint.py
+++ b/q2lint.py
@@ -8,7 +8,6 @@
 
 import pathlib
 import sys
-import glob
 
 
 def main():
@@ -28,14 +27,13 @@ def main():
             if header != HEADER:
                 errors.append('Invalid header: %s' % filepath)
 
-    npm_packages = filter(lambda x: 'node_modules' not in x,
-                          glob.glob('**/*/package.json', recursive=True))
+    npm_packages = filter(lambda x: 'node_modules' not in str(x),
+                          pathlib.Path('.').glob('**/*/package.json'))
     if npm_packages:
         import subprocess
-        import os
 
         for package in npm_packages:
-            pkg_path, _ = os.path.split(package)
+            pkg_path = package.parent
             cmd = 'cd %s && npm i && npm run build -- --bail && (git diff ' \
                   '--quiet */bundle.js || bash -c "exit 42")' % pkg_path
             res = subprocess.run(cmd, shell=True)

--- a/q2lint.py
+++ b/q2lint.py
@@ -38,7 +38,7 @@ def main():
                   '--quiet */bundle.js || bash -c "exit 42")' % pkg_path
             res = subprocess.run(cmd, shell=True)
             if res.returncode == 42:
-                errors.append('Bundle is not up to date for %s' % pkg_path)
+                errors.append('Bundle is out of sync for %s' % pkg_path)
             elif res.returncode != 0:
                 errors.append('npm build error on %s\n%s' %
                               (pkg_path, res.stderr))

--- a/q2lint.py
+++ b/q2lint.py
@@ -36,8 +36,8 @@ def main():
 
         for package in npm_packages:
             pkg_path, _ = os.path.split(package)
-            cmd = 'cd %s; npm i; npm run build; git diff --quiet || '\
-                  '(git checkout -- .; bash -c "exit -1")' % pkg_path
+            cmd = 'cd %s; npm i; npm run build; git diff --quiet */bundle.js' \
+                  ' || bash -c "exit -1"; git checkout -- .' % pkg_path
             if subprocess.run(cmd, shell=True).returncode != 0:
                 errors.append('npm build error on %s' % pkg_path)
 


### PR DESCRIPTION
Helps resolve an issue with visualizers, where the source either wasn't being rebuilt or wasn't built before opening the PR.