### PR TITLE
BUG: Python travis containers use extremely old Node.js

### DIFF
--- a/q2lint.py
+++ b/q2lint.py
@@ -38,6 +38,7 @@ def main():
 
         for package in npm_packages:
             pkg_path = package.parent
+            subprocess.run('nvm install --lts && nvm use --lts', shell=True)
             cmd = 'cd %s && npm i && npm run build -- --bail && (git diff ' \
                   '--quiet */bundle.js || bash -c "exit 42")' % pkg_path
             res = subprocess.run(cmd, shell=True)


### PR DESCRIPTION
Noticed in https://github.com/qiime2/q2-demux/pull/38

Travis' Python language containers have `{"node":"0.10.36","npm":"1.4.28"}`, which fails to do any sort of testing.

Unsure if this PR will fix it, but will patch demux's config to use this pull request specifically to test.