### PR TITLE
MAINT: Remove ancient bundle checking feature

### DIFF
--- a/q2lint/_main.py
+++ b/q2lint/_main.py
@@ -160,26 +160,6 @@ def validate_project(install_requires):
                     errors.append(
                         "Missing BSD-3-Clause license in pyproject.toml")
 
-    npm_packages = filter(lambda x: 'node_modules' not in str(x),
-                          pathlib.Path('.').glob('**/*/package.json'))
-    if npm_packages:
-        import subprocess
-
-        for package in npm_packages:
-            pkg_path = package.parent
-            install = 'cd %s && npm i --silent --progress false' % pkg_path
-            cmd = subprocess.run(install, shell=True,
-                                 stdout=subprocess.DEVNULL)
-            if cmd.returncode != 0:
-                errors.append('npm install failed')
-            cmd = 'cd %s && npm run build -- --bail && (git diff ' \
-                  '--quiet */bundle.js || bash -c "exit 42")' % pkg_path
-            res = subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL)
-            if res.returncode == 42:
-                errors.append('Bundle is out of sync for %s' % pkg_path)
-            elif res.returncode != 0:
-                errors.append('npm build error on %s' % pkg_path)
-
     if errors:
         sys.exit('\n\n\033[91m%s\033[0m\n\n' % '\n'.join(errors))
 


### PR DESCRIPTION
We don't include bundles in our packages anymore and haven't for so long that I forgot we ever did.

In any case, a package.json isn't a good hint anymore and the npm command assumes webpack is the bundler.